### PR TITLE
Beta link updates

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -28,7 +28,7 @@
             <h4>DOCS</h4>
             <ul>
               <li>
-                <a target="_blank" href="https://ros-planning.github.io/moveit_tutorials/">Tutorials</a>
+                <a target="_blank" href="https://moveit2_tutorials.picknik.ai/">Tutorials</a>
               </li>
               <li>
                 <a href="/documentation/applications/">Applications</a>

--- a/_includes/nav-bar.html
+++ b/_includes/nav-bar.html
@@ -34,11 +34,11 @@
             </div>
           </li>
           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="https://ros-planning.github.io/moveit_tutorials/" id="navbarDropdownDocs" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <a class="nav-link dropdown-toggle" href="https://moveit2_tutorials.picknik.ai/" id="navbarDropdownDocs" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               Docs
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdownDocs">
-              <a class="dropdown-item" target="_blank" href="https://ros-planning.github.io/moveit_tutorials/">Tutorials</a>
+              <a class="dropdown-item" target="_blank" href="https://moveit2_tutorials.picknik.ai/">Tutorials</a>
               <a class="dropdown-item" href="/documentation/applications/">Applications</a>
               <a class="dropdown-item" href="/documentation/concepts/">Concepts</a>
               <a class="dropdown-item" href="/documentation/related_projects/">Related Projects</a>

--- a/_posts/2017-09-20-world-moveit-day.markdown
+++ b/_posts/2017-09-20-world-moveit-day.markdown
@@ -20,7 +20,7 @@ We will be having several event locations including:
 - [Verb Surgical](http://www.verbsurgical.com/), San Francisco Bay Area
 - [Magazino](https://www.magazino.eu/), Munich, Germany
 - [Southwest Research Institute](http://www.swri.org/ros-industrial), San Antonio, USA
-- [Xamla Robotics (PROVISIO GmbH)](http://xamla.com/en/), Münster, Germany
+- Xamla Robotics (PROVISIO GmbH), Münster, Germany
 - [ROS-Industrial Asian Pacific Consortium](http://rosindustrial.org/ric-apac/), Singapore (THURSDAY OCTOBER 19th)
 - [PickNik Robotics (Univ. Colorado)](http://picknik.ai), Boulder, USA
 - [Shadow Robot Company](https://www.shadowrobot.com), London, UK

--- a/about/citations/index.markdown
+++ b/about/citations/index.markdown
@@ -14,9 +14,9 @@ title: About
           <p>David Coleman, Ioan A. Șucan, Sachin Chitta, Nikolaus Correll,
           Reducing the Barrier to Entry of Complex Robotic Software: a MoveIt! Case Study,
           <em>Journal of Software Engineering for Robotics</em>,
-          5(1):3–16, May 2014. doi: <a href="http://dx.doi.org/10.6092/JOSER_2014_05_01_p3">10.6092/JOSER_2014_05_01_p3</a>.</p>
-          <p class="text-center"><a class="button" href="https://arxiv.org/pdf/1404.3785">PDF</a>
-          <a class="button" href="http://dx.doi.org/10.6092/JOSER_2014_05_01_p3">Publisher</a></p>
+          5(1):3–16, May 2014. doi: <a href="http://dx.doi.org/10.6092/JOSER_2014_05_01_p3" target="_blank">10.6092/JOSER_2014_05_01_p3</a>.</p>
+          <p class="text-center"><a class="button" href="https://arxiv.org/pdf/1404.3785" target="_blank">PDF</a>
+          <a class="button" href="http://dx.doi.org/10.6092/JOSER_2014_05_01_p3" target="_blank">Publisher</a></p>
         </div>
         <div class="main-card-single boarder main-card-single-padding">
           <img class="mx-auto d-block quote-img" src="/assets/images/people_page/quote.png">
@@ -31,9 +31,9 @@ title: About
       <div class="main-card-wrapper">
         <div class="main-card-single boarder main-card-single-padding">
           <h3>MoveIt Task Constructor</h3>
-          <p>M. Görner, R. Haschke, H. Ritter, and J. Zhang, “Moveit! task constructor for task-level motion planning,” in <em>IEEE Intl. Conf. on Robotics and Automation</em>, pp. 190–196, May 2019. doi: <a href="https://ieeexplore.ieee.org/document/8793898">10.1109/ICRA.2019.8793898</a>.</p>
-          <p class="text-center"><a class="button" href="https://pub.uni-bielefeld.de/download/2918864/2933599/paper.pdf">PDF</a>
-          <a class="button" href="https://ieeexplore.ieee.org/document/8793898">Publisher</a></p>
+          <p>M. Görner, R. Haschke, H. Ritter, and J. Zhang, “Moveit! task constructor for task-level motion planning,” in <em>IEEE Intl. Conf. on Robotics and Automation</em>, pp. 190–196, May 2019. doi: <a href="https://www.researchgate.net/publication/335138707_MoveIt_Task_Constructor_for_Task-Level_Motion_Planning" target="_blank">10.1109/ICRA.2019.8793898</a>.</p>
+          <p class="text-center"><a class="button" href="https://pub.uni-bielefeld.de/download/2918864/2933599/paper.pdf" target="_blank">PDF</a>
+          <a class="button" href="https://www.researchgate.net/publication/335138707_MoveIt_Task_Constructor_for_Task-Level_Motion_Planning" target="_blank">Publisher</a></p>
       </div>
     </div>
   </div>

--- a/about/citations/index.markdown
+++ b/about/citations/index.markdown
@@ -20,7 +20,7 @@ title: About
         </div>
         <div class="main-card-single boarder main-card-single-padding">
           <img class="mx-auto d-block quote-img" src="/assets/images/people_page/quote.png">
-          <p>Ioan A. Sucan and Sachin Chitta, "MoveIt", [Online] Available at <a href="https://moveit.ros.org">moveit.ros.org</a>.</p>
+          <p>Ioan A. Sucan and Sachin Chitta, "MoveIt", [Online] Available at <a href="/">moveit.ros.org</a>.</p>
         </div>
       </div>
     </div>

--- a/about/index.markdown
+++ b/about/index.markdown
@@ -323,12 +323,12 @@ title: About
         <div class="sponsors-card-single">
           <img class="mx-auto d-block" src="/assets/images/sponsors/acutronicrobotics.jpg" alt="Acutronic">
           Acutronic sponsored a collaborative effort in 2019 to begin the port of MoveIt to ROS 2.0.
-          <a href="https://moveit.ros.org/moveit!/ros/2019/03/01/announcing-the-moveit-2-port.html">Learn More</a>
+          <a href="/moveit!/ros/2019/03/01/announcing-the-moveit-2-port.html">Learn More</a>
         </div>
         <div class="sponsors-card-single">
           <img class="mx-auto d-block" src="/assets/images/sponsors/franka_logo.png" alt="Franka Emika">
           Franka Emika sponsored a codesprint in 2018 to improve MoveIt’s tutorials, documentation, and website.
-          <a href="http://moveit.ros.org/moveit!/ros/2018/02/26/tutorials-documentation-codesprint.html">Learn More</a>
+          <a href="/moveit!/ros/2018/02/26/tutorials-documentation-codesprint.html">Learn More</a>
         </div>
       </div>
     </div>

--- a/about/maintainer_policy/index.markdown
+++ b/about/maintainer_policy/index.markdown
@@ -61,7 +61,7 @@ When the following occurs for a Maintainer or Core Contributor:
  - They have no MoveIt Github activity, or have not attended any Maintainer meetings, for an entire year
 
 Then we will first reach out to them to check in and encourage participation.
-If there is no further desire or ability to continue to be an active member of the MoveIt team, we will move them to the "Inactive" section of the [People](https://moveit.ros.org/about/) page.
+If there is no further desire or ability to continue to be an active member of the MoveIt team, we will move them to the "Inactive" section of the [People](/about/) page.
 Their past contributions should be acknowledged and appreciated, and they will continue to be listed on the MoveIt page.
 
 For maintainers specifically, we will also remove their repo commit access and change them to just Github Triage access.

--- a/documentation/applications/index.markdown
+++ b/documentation/applications/index.markdown
@@ -9,7 +9,7 @@ title: Applications
 
 # MoveIt Applications
 
-There are many diverse application examples of what you can use MoveIt for. The list below demonstrates some of the advanced applications developed on MoveIt. You can have fun by trying the applications, which may help you figure out how to fit different features together. If you are interested, you can visit [MoveIt Tutorials](https://ros-planning.github.io/moveit_tutorials/) for further technical details. At the same time, your contribution is encouraged, no matter the application is developed for some usages, competitions or research topics, or to demonstrate the newly developed MoveIt feature.
+There are many diverse application examples of what you can use MoveIt for. The list below demonstrates some of the advanced applications developed on MoveIt. You can have fun by trying the applications, which may help you figure out how to fit different features together. If you are interested, you can visit [MoveIt Tutorials](https://moveit2_tutorials.picknik.ai/) for further technical details. At the same time, your contribution is encouraged, no matter the application is developed for some usages, competitions or research topics, or to demonstrate the newly developed MoveIt feature.
 
 ## MoveIt Example Apps
 

--- a/documentation/concepts/index.markdown
+++ b/documentation/concepts/index.markdown
@@ -9,7 +9,7 @@ title: Concepts
 
 # Concepts
 
-The following is an overview of how MoveIt works. For more concrete documentation and details see the [tutorials](https://ros-planning.github.io/moveit_tutorials/) or the [developers' concepts](/documentation/concepts/developer_concepts/).
+The following is an overview of how MoveIt works. For more concrete documentation and details see the [tutorials](https://moveit2_tutorials.picknik.ai/) or the [developers' concepts](/documentation/concepts/developer_concepts/).
 
 ## System Architecture
 
@@ -30,7 +30,7 @@ The users can access the actions and services provided by _move_group_ in one of
 
 - **In Python** - using the [moveit_commander](http://docs.ros.org/noetic/api/moveit_commander/html/classmoveit__commander_1_1move__group_1_1MoveGroupCommander.html) package
 
-- **Through a GUI** - using the [Motion Planning plugin to Rviz](https://ros-planning.github.io/moveit_tutorials/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.html) (the ROS visualizer)
+- **Through a GUI** - using the [Motion Planning plugin to Rviz](https://moveit2_tutorials.picknik.ai/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.html) (the ROS visualizer)
 
 _move_group_ can be configured using the ROS param server from where it will also get the URDF and SRDF for the robot.
 
@@ -173,7 +173,7 @@ MoveIt uses a plugin infrastructure, especially targeted towards allowing users 
 
 ### **IKFast Plugin**
 
-Often, users may choose to implement their own kinematics solvers, e.g. the PR2 has its own kinematics solvers. A popular approach to implementing such a solver is using the [IKFast package](https://ros-planning.github.io/moveit_tutorials/doc/ikfast/ikfast_tutorial.html) to generate the C++ code needed to work with your particular robot.
+Often, users may choose to implement their own kinematics solvers, e.g. the PR2 has its own kinematics solvers. A popular approach to implementing such a solver is using the [IKFast package](https://moveit2_tutorials.picknik.ai/doc/ikfast/ikfast_tutorial.html) to generate the C++ code needed to work with your particular robot.
 
 ---
 

--- a/documentation/contributing/future_projects/index.markdown
+++ b/documentation/contributing/future_projects/index.markdown
@@ -127,7 +127,7 @@ For this, we need to identify and implement standard tasks at varying levels of 
 - **Programming skills**: C++
 - **Difficulty**: Medium
 - **Potential mentors**: Robert Haschke, Henning Kayser
-- **Description**: The [MoveIt Task Constructor](https://ros-planning.github.io/moveit_tutorials/doc/moveit_task_constructor/moveit_task_constructor_tutorial.html) framework provides a flexible and transparent way to define and plan actions that consist of multiple interdependent subtasks. It draws on the planning capabilities of MoveIt to solve individual subproblems in black-box planning stages. Porting this to MoveIt 2 may also include porting MoveIt 1's MoveGroup interface to MoveIt 2.
+- **Description**: The [MoveIt Task Constructor](https://moveit2_tutorials.picknik.ai/doc/moveit_task_constructor/moveit_task_constructor_tutorial.html) framework provides a flexible and transparent way to define and plan actions that consist of multiple interdependent subtasks. It draws on the planning capabilities of MoveIt to solve individual subproblems in black-box planning stages. Porting this to MoveIt 2 may also include porting MoveIt 1's MoveGroup interface to MoveIt 2.
 
 <a name="ros-control-integration"></a>
 

--- a/documentation/contributing/index.markdown
+++ b/documentation/contributing/index.markdown
@@ -57,9 +57,12 @@ title: Contributing
     </span>
     <h3>Enhancing Documentation</h3>
     <p>
-      Our documentation is of course open source and we strongly encourage you to improve it as you learn MoveIt yourself and find mistakes. ✨ It lives in two different repos on Github:
+      Our documentation is of course open source and we strongly encourage you to improve it as you learn MoveIt yourself and find mistakes. ✨ It lives in three different repos on Github:
     </p>
     <ul>
+    <li>
+        <a href="https://github.com/ros-planning/moveit2_tutorials" target="_blank">https://github.com/ros-planning/moveit2_tutorials</a>
+      </li>
       <li>
         <a href="https://github.com/ros-planning/moveit_tutorials" target="_blank">https://github.com/ros-planning/moveit_tutorials</a>
       </li>

--- a/documentation/contributing/releases/index.markdown
+++ b/documentation/contributing/releases/index.markdown
@@ -97,7 +97,7 @@ The maintainer handling the release must have write access to both devel repos (
 ```
 # MoveIt <ROS_VERSION_NAME> Release (<VERSION>)
 
-[_moveit.ros.org release documentation_](https://moveit.ros.org/documentation/contributing/releases/)
+[_moveit.ros.org release documentation_](/documentation/contributing/releases/)
 
 ### Backports
 

--- a/documentation/contributing/roadmap/index.markdown
+++ b/documentation/contributing/roadmap/index.markdown
@@ -20,7 +20,7 @@ title: MoveIt Roadmap
 <div class="row current-version roadmap-current-version">
   <div class='col-sm-12 time-line-wrappper time-line-wrapper-future'>
     <h3>MoveIt 2.2 Galactic Geochelone</h3>
-    <a class="button button-transparent button-transparent__blue" href="https://moveit.ros.org/documentation/contributing/roadmap/" target="_blank">See Every 6 Week Release Schedule</a>
+    <a class="button button-transparent button-transparent__blue" href="/documentation/contributing/releases/">See Every 6 Week Release Schedule</a>
     <div class="time-line">
         <div class="time-line--orange" id="time-line--orange-2"></div>
         <div class="time-line--blue" id="time-line--blue-2"></div>

--- a/documentation/faqs/index.markdown
+++ b/documentation/faqs/index.markdown
@@ -21,7 +21,7 @@ _What version of MoveIt should I use?_
 
   * For most developers, we recommend building the [master](https://github.com/ros-planning/moveit) branch from source.
   * If you are a beginner, installing the Noetic LTS release from Debian is the easiest and fastest.
-  * You can also use a [Docker container](https://moveit.ros.org/install/docker/) for a virtual setup.
+  * You can also use a [Docker container](/install/docker/) for a virtual setup.
 
 _Should I build from source or install the Debians?_
 
@@ -31,8 +31,8 @@ _Should I build from source or install the Debians?_
 
 _What kind of computer do I need?_
 
-  * ROS 1.0 works best on a Linux computer, particularly Ubuntu 16.04 or 18.04. [Some Windows support](https://moveit.ros.org/install/) is also available.
-  * If you are running another operating system, we recommend to try dual booting, [installing on Docker](https://moveit.ros.org/install/docker/), or using a virtual machine (see [notes](https://moveit.ros.org/install/)).
+  * ROS 1.0 works best on a Linux computer, particularly Ubuntu 16.04 or 18.04. [Some Windows support](/install/) is also available.
+  * If you are running another operating system, we recommend to try dual booting, [installing on Docker](/install/docker/), or using a virtual machine (see [notes](/install/)).
 
 _Where is the source code?_
 
@@ -40,7 +40,7 @@ _Where is the source code?_
 
 _How do I create a pull request?_
 
-  * [Contributing](https://moveit.ros.org/documentation/contributing/) fixes and features back to MoveIt is not as hard as it may seem, everyone is encouraged to do it!
+  * [Contributing](/documentation/contributing/) fixes and features back to MoveIt is not as hard as it may seem, everyone is encouraged to do it!
   * The high level is:
     * Create a [Github fork](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks) of MoveIt
     * [Clone the repo](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) locally
@@ -59,7 +59,7 @@ _What is the difference between MoveIt 1 and MoveIt 2?_
 
   * MoveIt 2 is currently (April 2020) a straight port of MoveIt 1 but for ROS 2.
   * ROS 2 is a total rewrite of the popular robotics middleware that addresses many unfulfilled needs of industry / commercial users in ROS 1.
-  * MoveIt 2 will hopefully fork from MoveIt 1 soon to take advantage of the new features in ROS 2. See the [roadmap](https://moveit.ros.org/documentation/contributing/roadmap/).
+  * MoveIt 2 will hopefully fork from MoveIt 1 soon to take advantage of the new features in ROS 2. See the [roadmap](/documentation/contributing/roadmap/).
 
 _What is the difference between MoveIt and ROS?_
 
@@ -77,7 +77,7 @@ _What is the difference between MoveIt and OMPL?_
 
 _What is the difference between MoveIt and PickNik?_
 
-  * MoveIt is an open source project that started at Willow Garage (see [history](https://moveit.ros.org/about/)) and is now led by [PickNik Robotics](https://picknik.ai/).
+  * MoveIt is an open source project that started at Willow Garage (see [history](/about/)) and is now led by [PickNik Robotics](https://picknik.ai/).
   * PickNik was founded by lead MoveIt maintainer Dave Coleman with the mission of growing the MoveIt project through community building and contract consulting.
 
 _What is the difference between MoveIt and ROS-Industrial?_
@@ -94,7 +94,7 @@ _I have a fix for a bug in the MoveIt tutorials. What should I do?_
 
 _I have a found a bug in MoveIt itself. What should I do?_
 
-  * See [Contributing](http://moveit.ros.org/documentation/contributing/)
+  * See [Contributing](/documentation/contributing/)
 
 ## Robots
 

--- a/documentation/faqs/index.markdown
+++ b/documentation/faqs/index.markdown
@@ -15,7 +15,7 @@ title: FAQs
 
 _I'm totally new, how do I get started?_
 
-  * See the [tutorials](https://ros-planning.github.io/moveit_tutorials/) &#128540;
+  * See the [tutorials](https://moveit2_tutorials.picknik.ai/) &#128540;
 
 _What version of MoveIt should I use?_
 

--- a/events/world-moveit-day-2017/index.markdown
+++ b/events/world-moveit-day-2017/index.markdown
@@ -27,7 +27,7 @@ World MoveIt Day is an international hackathon to improve the MoveIt code base, 
   - Contact: Nikolas Engelhard
 - [Southwest Research Institute](http://www.swri.org/ros-industrial), San Antonio, USA
   - Contact: Jorge Nicho
-- [Xamla Robotics (PROVISIO GmbH)](http://xamla.com/en/), Münster, Germany
+- Xamla Robotics (PROVISIO GmbH), Münster, Germany
   - Contact: Andreas Köpf
 - [ROS-Industrial Asian Pacific Consortium](http://rosindustrial.org/ric-apac/), Singapore
   - Contact: Chan Min Ling

--- a/index.markdown
+++ b/index.markdown
@@ -44,7 +44,7 @@ redirect_from: '/moveit/'
                                 Watch overview
                                 </button>
                                 <a class="button button-yellow modal-link" href="https://www.youtube-nocookie.com/embed/7KvF7Dj7bz0" target="_blank">Watch overview</a>
-                                <a class="button button-transparent" href="http://docs.ros.org/melodic/api/moveit_tutorials/html/index.html" target="_blank">Get Started</a>
+                                <a class="button button-transparent" href="http://moveit2_tutorials.picknik.ai/" target="_blank">Get Started</a>
                             </div>
                         </div>
                     </div>

--- a/index.markdown
+++ b/index.markdown
@@ -239,7 +239,7 @@ redirect_from: '/moveit/'
                     <div class="col-xs-12 col-lg-5 col-sm-12">
                         <h1>Why MoveIt?</h1>
                         <p class="paragraph-big">
-                            MoveIt is the most widely used software for manipulation and has been used on over <a href="https://moveit.ros.org/robots/">150 robots</a>. It is released under the terms of the BSD license, and thus free for industrial, commercial, and research use.
+                            MoveIt is the most widely used software for manipulation and has been used on over <a href="/robots/">150 robots</a>. It is released under the terms of the BSD license, and thus free for industrial, commercial, and research use.
                         </p>
                         <p class="paragraph-big">
                             By incorporating the latest advances in motion planning, manipulation, 3D perception, kinematics, control and navigation, MoveIt is state of the art software for mobile manipulation.
@@ -298,7 +298,7 @@ redirect_from: '/moveit/'
                 <!-- </div> -->
                 <div class='col-sm-12 time-line-wrappper time-line-wrapper-future'>
                     <h3>MoveIt 2.2 Galactic Geochelone</h3>
-                    <a class="button button-transparent" href="https://moveit.ros.org/documentation/contributing/roadmap/" target="_blank">SEE ROADMAP</a>
+                    <a class="button button-transparent" href="/documentation/contributing/roadmap/" target="_blank">SEE ROADMAP</a>
                     <div class="time-line">
                         <div class="time-line--orange" id="time-line--orange-2"></div>
                         <div class="time-line--blue" id="time-line--blue-2"></div>

--- a/install/index.markdown
+++ b/install/index.markdown
@@ -335,7 +335,7 @@ title: MoveIt 1 Binary Install
       <p>
         MoveIt is released every few months into Ubuntu debian packages via
         the ROS infrastructure. For more information see the <a href="https://www.ros.org/reps/rep-0003.html" target="_blank">ROS target platforms</a>
-        and <a href="https://moveit.ros.org/documentation/contributing/pullrequests/" target="_blank">MoveIt’s release process</a>.
+        and <a href="/documentation/contributing/pullrequests/">MoveIt’s release process</a>.
       </p>
     </div>
   </div>

--- a/media/index.markdown
+++ b/media/index.markdown
@@ -7,4 +7,4 @@ slug: media
 title: Media
 ---
 
-The contents of this page has moved to the [homepage](http://moveit.ros.org/).
+The contents of this page has moved to the [homepage](/).

--- a/support/index.markdown
+++ b/support/index.markdown
@@ -61,7 +61,10 @@ title: Support
         <a href="https://github.com/ros-planning/moveit.ros.org/issues" target="_blank">moveit.ros.org</a> - Issues related to the Jekyll-based website
       </li>
       <li>
-        <a href="https://github.com/ros-planning/moveit_tutorials" target="_blank">moveit_tutorials</a> - Issues related to the Sphinx-based tutorials
+        <a href="https://github.com/ros-planning/moveit_tutorials" target="_blank">moveit1_tutorials</a> - Issues related to the Sphinx-based Moveit1 tutorials
+      </li>
+      <li>
+        <a href="https://github.com/ros-planning/moveit2_tutorials" target="_blank">moveit2_tutorials</a> - Issues related to the Sphinx-based Moveit2 tutorials
       </li>
     </ul>
     <h3>Change Logs and Migration Notes</h3>


### PR DESCRIPTION
### Description

Updated all the links to point to moveit2_tutorials, replaced "moveit.ros.org" links with "/" to reference current site, and fixed broken links from htmlproofer.

### Checklist
- [ ] Tested modified webpage locally using the ``build_locally.sh`` script
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
